### PR TITLE
Removed all the references to FASSE that were previously not removed

### DIFF
--- a/handbook/analysis.md
+++ b/handbook/analysis.md
@@ -59,11 +59,9 @@ This is important so that shared repository URLs are not broken. In this case, d
 
 ## Creating a GitHub repository in CANNON
 
-Once you have created a repository on GitHub, you can clone that repository into CANNON, so that you can transfer versions of your files to and from CANNON and GitHub. To clone a GitHub repository into CANNON, start a CANNON Remote Desktop (or Containerized Remote Desktop) session, Open a Terminal window, and write the following lines one-by-one. Note that the first and second lines are different from each other because the first says "http" and second says "https".
+Once you have created a repository on GitHub, you can clone that repository into CANNON, so that you can transfer versions of your files to and from CANNON and GitHub. To clone a GitHub repository into CANNON, start a CANNON Remote Desktop session, Open a Terminal window, and write the following lines one-by-one.
 
 ```shell
-export http_proxy=http://rcproxy.rc.fas.harvard.edu:3128
-export https_proxy=http://rcproxy.rc.fas.harvard.edu:3128
 cd nsaph_projects/{your project name}
 git clone {url of your repository: go to your repository and click on green "Code" button}
 ```
@@ -76,7 +74,7 @@ As you code in CANNON, it's good practice to upload your code to GitHub often, p
 2. you're about to ask someone for coding help or you're about to present your research and people may want to see your code, or even 
 3. you yourself want to see your code without logging into CANNON.
 
-To add files from CANNON to GitHub, start a Remote Desktop (or Containerized Remote Desktop) session. 
+To add files from CANNON to GitHub, start a Remote Desktop session. 
 Open a Terminal window AFTER you're done editing your files (if you open Terminal before you've finished making edits, you'll end up uploading an old version of your code) and type the following lines one by one.
 
 All of the `git status` lines are optional; `git status` simply lets you see what files are in the current folder, 

--- a/handbook/analysis.md
+++ b/handbook/analysis.md
@@ -55,11 +55,11 @@ This is important so that shared repository URLs are not broken. In this case, d
 :::
 
 
-# Tips for using FASSE and NSAPH GitHub 
+# Tips for using CANNON and NSAPH GitHub 
 
-## Creating a GitHub repository in FASSE
+## Creating a GitHub repository in CANNON
 
-Once you have created a repository on GitHub, you can clone that repository into FASSE, so that you can transfer versions of your files to and from FASSE and GitHub. To clone a GitHub repository into FASSE, start a FASSE Remote Desktop (or Containerized Remote Desktop) session, Open a Terminal window, and write the following lines one-by-one. Note that the first and second lines are different from each other because the first says "http" and second says "https".
+Once you have created a repository on GitHub, you can clone that repository into CANNON, so that you can transfer versions of your files to and from CANNON and GitHub. To clone a GitHub repository into CANNON, start a CANNON Remote Desktop (or Containerized Remote Desktop) session, Open a Terminal window, and write the following lines one-by-one. Note that the first and second lines are different from each other because the first says "http" and second says "https".
 
 ```shell
 export http_proxy=http://rcproxy.rc.fas.harvard.edu:3128
@@ -68,15 +68,15 @@ cd nsaph_projects/{your project name}
 git clone {url of your repository: go to your repository and click on green "Code" button}
 ```
     
-## Uploading files from FASSE to GitHub
+## Uploading files from CANNON to GitHub
 
-As you code in FASSE, it's good practice to upload your code to GitHub often, particular when 
+As you code in CANNON, it's good practice to upload your code to GitHub often, particular when 
 
 1. you've made or are about to make significant changes  (this way, you'll be able to access the current or old versions later and see the changes you've made), or 
 2. you're about to ask someone for coding help or you're about to present your research and people may want to see your code, or even 
-3. you yourself want to see your code without logging into FASSE.
+3. you yourself want to see your code without logging into CANNON.
 
-To add files from FASSE to GitHub, start a Remote Desktop (or Containerized Remote Desktop) session. 
+To add files from CANNON to GitHub, start a Remote Desktop (or Containerized Remote Desktop) session. 
 Open a Terminal window AFTER you're done editing your files (if you open Terminal before you've finished making edits, you'll end up uploading an old version of your code) and type the following lines one by one.
 
 All of the `git status` lines are optional; `git status` simply lets you see what files are in the current folder, 
@@ -104,7 +104,7 @@ Your commit message should be informative. For example: "update stratification" 
 ```
 
 ```{tip}
-If you've set up a personal access token for GitHub, you could save your PAT as a text file in your private FASSE folder.
+If you've set up a personal access token for GitHub, you could save your PAT as a text file in your private CANNON folder.
 ```
 
 ## Obtaining GitHub Token

--- a/handbook/bashrc.md
+++ b/handbook/bashrc.md
@@ -4,59 +4,21 @@ The `.bashrc` file is a script executed whenever a new terminal session starts i
 
 ## Setting up a `.bashrc` file in CANNON:
 1. Log into CANNON and open Terminal
-2. Navigate to your home directory. There should already be a `.bashrc` file in this directory.
-3. Open and edit it with at least the following configurations to allow you to use Python, Git, and VS Code, manage conda environments, and submit VS Code jobs to the CANNON cluster.
+2. Navigate to your home directory. There should already by a `.bashrc` file in this directory. 
+3. Open and edit it with at least the following configurations to allow you to use Python, Git, and VS Code. 
 
 ```bash
-# .bashrc
-# Source global definitions
-if [ -f /etc/bashrc ]; then
-    . /etc/bashrc
-fi
+   # .bashrc
 
-function mm() {
-    module load vscode
-    module load git
-    module load python
-}
+   # Source global definitions
+   if [ -f /etc/bashrc ]; then
+       . /etc/bashrc
+   fi
 
-submit_vscode_job() {
-    local output
-    local p=$1
-    local mem=$2
-    local cpus=$3
-    local time=$4
-    echo "sbatch -p $p --mem=$mem -c $cpus --time=$time /n/home##/<your-username>/vscode.job"
-    output=$(sbatch -p $p --mem=$mem -c $cpus --time=$time /n/home##/<your-username>/vscode.job)
-    export VSCODEJOBID=$(echo "$output" | awk '{print $4}')
-    echo "Job submitted with ID: $VSCODEJOBID"
-    log_file=~/vscode/logs/vscode-sbatch_${VSCODEJOBID}.out
-    echo -n "Waiting for log file: $log_file "
-    spin_chars='|/-\'
-    while [ ! -f "$log_file" ]; do
-        for i in {0..3}; do
-            echo -ne "\b${spin_chars:$i:1}"
-            sleep 0.2
-        done
-    done
-    echo -e "\b✔ Log file detected, VSCode started!"
-    cat "$log_file"
-    echo "Job in process."
-}
-alias launch='submit_vscode_job'
-
-export WORK="/n/dominici_lab/lab"
-export CONDA_PKGS_DIRS=/n/dominici_lab/lab/data_processing/conda/pkgs
-export CONDA_ENVS_PATH=/n/dominici_lab/lab/data_processing/conda/envs
-```
-
-4. Load the modules configured in the `.bashrc` by running your function in Terminal (e.g., `mm`)
-5. To submit a VS Code job to the cluster, use the `launch` alias with your desired partition, memory, CPUs, and time:
-```bash
-   launch short 8G 4 0-02:00
-```
-   NSAPH members also have access to the `hsph` partition:
-```bash
-   launch hsph 8G 4 0-02:00
-```
-   For instructions on setting up your `vscode.job` file, see the [Harvard RC VS Code documentation](https://docs.rc.fas.harvard.edu/kb/vscode-remote-development-via-ssh-or-tunnel/).
+   function mm() {
+       module load vscode 
+       module load git
+       module load python
+   } 
+   ```  
+4. Load the the modules configured in the `.bashrc ` by running your function in Terminal (e.g., `mm`)

--- a/handbook/bashrc.md
+++ b/handbook/bashrc.md
@@ -4,27 +4,59 @@ The `.bashrc` file is a script executed whenever a new terminal session starts i
 
 ## Setting up a `.bashrc` file in CANNON:
 1. Log into CANNON and open Terminal
-2. Navigate to your home directory. There should already by a `.bashrc` file in this directory. 
-3. Open and edit it with at least the following configurations to allow you to use Python, Git, and VS Code. 
+2. Navigate to your home directory. There should already be a `.bashrc` file in this directory.
+3. Open and edit it with at least the following configurations to allow you to use Python, Git, and VS Code, manage conda environments, and submit VS Code jobs to the CANNON cluster.
 
 ```bash
-   # .bashrc
+# .bashrc
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+    . /etc/bashrc
+fi
 
-   # Source global definitions
-   if [ -f /etc/bashrc ]; then
-       . /etc/bashrc
-   fi
+function mm() {
+    module load vscode
+    module load git
+    module load python
+}
 
-   function mm() {
-       module load vscode 
-       module load git
-       module load python
-   } 
+submit_vscode_job() {
+    local output
+    local p=$1
+    local mem=$2
+    local cpus=$3
+    local time=$4
+    echo "sbatch -p $p --mem=$mem -c $cpus --time=$time /n/home##/<your-username>/vscode.job"
+    output=$(sbatch -p $p --mem=$mem -c $cpus --time=$time /n/home##/<your-username>/vscode.job)
+    export VSCODEJOBID=$(echo "$output" | awk '{print $4}')
+    echo "Job submitted with ID: $VSCODEJOBID"
+    log_file=~/vscode/logs/vscode-sbatch_${VSCODEJOBID}.out
+    echo -n "Waiting for log file: $log_file "
+    spin_chars='|/-\'
+    while [ ! -f "$log_file" ]; do
+        for i in {0..3}; do
+            echo -ne "\b${spin_chars:$i:1}"
+            sleep 0.2
+        done
+    done
+    echo -e "\b✔ Log file detected, VSCode started!"
+    cat "$log_file"
+    echo "Job in process."
+}
+alias launch='submit_vscode_job'
 
-   export MY_NSAPH_SSH_USERNAME="USERNAME"
-   export MY_NSAPH_SSH_PASSWORD="PASSWORD"
-   export http_proxy=http://rcproxy.rc.fas.harvard.edu:3128
-   export https_proxy=http://rcproxy.rc.fas.harvard.edu:3128
-   WORK="/n/dominici_lab/lab"
-   ```  
-4. Load the the modules configured in the `.bashrc ` by running your function in Terminal (e.g., `mm`)
+export WORK="/n/dominici_lab/lab"
+export CONDA_PKGS_DIRS=/n/dominici_lab/lab/data_processing/conda/pkgs
+export CONDA_ENVS_PATH=/n/dominici_lab/lab/data_processing/conda/envs
+```
+
+4. Load the modules configured in the `.bashrc` by running your function in Terminal (e.g., `mm`)
+5. To submit a VS Code job to the cluster, use the `launch` alias with your desired partition, memory, CPUs, and time:
+```bash
+   launch short 8G 4 0-02:00
+```
+   NSAPH members also have access to the `hsph` partition:
+```bash
+   launch hsph 8G 4 0-02:00
+```
+   For instructions on setting up your `vscode.job` file, see the [Harvard RC VS Code documentation](https://docs.rc.fas.harvard.edu/kb/vscode-remote-development-via-ssh-or-tunnel/).

--- a/handbook/dua.md
+++ b/handbook/dua.md
@@ -1,11 +1,11 @@
 # Data Usage Policies
 
-We would like to take this opportunity to make sure that all FASSE/RED users have read the following
+We would like to take this opportunity to make sure that all RED users have read the following
 usage policy and agree to it. Please take a few minutes to read the information below.
 
 ## Data Access
 
-**1. FASSE/RED accounts are individual accounts that are not sharable.**
+**1. RED accounts are individual accounts that are not sharable.**
 
 *You are not allowed to share your account password with anyone. Allowing other individuals to log into your account or use your account is a violation of our DUA and will result in immediate termination of your account.*
 
@@ -23,10 +23,10 @@ usage policy and agree to it. Please take a few minutes to read the information 
 
 ## Data Sharing
 
-**1. Health data CANNOT be moved from the FASSE/RED.**
+**1. Health data CANNOT be moved from the RED.**
 
-*Per the DUA and IRB, data has to be on the FASSE/RED data cluster ONLY and cannot be 
-downloaded from the computing clusters. Datasets CANNOT be downloaded or moved from FASSE/RED even if they do not have identifying information. Violations come with serious consequences that jeopardize everyone's work. We are very much encouraging sharing reproducible code on GitHub, but please use 
+*Per the DUA and IRB, data has to be on the RED data cluster ONLY and cannot be 
+downloaded from the computing clusters. Datasets CANNOT be downloaded or moved from RED even if they do not have identifying information. Violations come with serious consequences that jeopardize everyone's work. We are very much encouraging sharing reproducible code on GitHub, but please use 
 it only for CODE and publicly available data. We suggest adding a `.gitignore` file to your 
 repository and using it to prevent unintentional upload of data files. We also suggest using 
 the `git status` command before committing to confirm what you are committing.*
@@ -41,17 +41,17 @@ the `git status` command before committing to confirm what you are committing.*
 
 *Inefficient use of compute resources by a single user can prevent the entire team from getting work done. Users should develop and benchmark their models using the Rstudio profiler on small subsets of their data prior to grabbing large chunks of memory. We monitor compute usage, and users using the cluster inefficiently may have their jobs cancelled.*
 
-**2. Set up GitHub under [NSAPH-Projects](https://github.com/orgs/NSAPH-Projects) and link it to FASSE/RED project space.**
+**2. GitHub is not supported in the ReD environment**
 
-*For more details, please see instructions [here](https://nsaph.github.io/handbook/fasse.html#step-4-create-a-git-repository-on-github).*
+*GitHub access is not available within the ReD environment. Users should not clone, pull, or push repositories from within ReD. All code should be developed and maintained within the ReD lab share using approved compute environments. Any use of external platforms such as GitHub must follow NSAPH data security and governance policies.*
 
 **3. Work under the project space, and not in your home folder.**
 
-*Instructions on how to create a project folder and a GitHub repository can be found [*here*](https://nsaph.github.io/handbook/fasse.html#step-3-project-workspace).*
+*All work should be conducted within the appropriate project directories in the ReD lab share, not in personal home folders. This ensures proper organization, supports collaboration, and aligns with the standard project structure used across ReD. Additional guidance on working within the ReD environment can be found [here](https://nsaph.github.io/handbook/red.html).*
 
-**4. Use a Symbolic link to read in data from your project folder.**
+**4. Access shared data from the ReD lab share**
 
-*In order to use any of the analytic datasets available under the dominici_nsaph FASSE group, please make sure to use a symbolic link to read in data from your project folder located under `/n/dominici_nsaph_l3/Lab/projects`. **Please do not copy the data**; we have limited storage capacity and cannot have multiple copies of the data. For more information on this step, click [here](https://nsaph.github.io/handbook/fasse.html#step-5-analytic-data).*
+*Users should access datasets from approved locations within the ReD lab share and should not create duplicate copies of data within project directories. Maintaining a single authoritative version of datasets supports data integrity and efficient use of storage Where appropriate, mechanisms such as symbolic links may be used to reference shared datasets instead of copying them.*
 
 **Useful links on data privacy **
 - "*Why Anonymous Data Sometimes Isn't*"

--- a/handbook/dua.md
+++ b/handbook/dua.md
@@ -43,7 +43,7 @@ the `git status` command before committing to confirm what you are committing.*
 
 **2. GitHub is not supported in the ReD environment**
 
-*GitHub access is not available within the ReD environment. Users should not clone, pull, or push repositories from within ReD. All code should be developed and maintained within the ReD lab share using approved compute environments. Any use of external platforms such as GitHub must follow NSAPH data security and governance policies.*
+*GitHub access is not available within the ReD environment. Users should not clone, pull, or push repositories from within ReD. All code should be developed and maintained within the ReD lab share using approved compute environments.*
 
 **3. Work under the project space, and not in your home folder.**
 

--- a/handbook/lego_data_model.md
+++ b/handbook/lego_data_model.md
@@ -64,7 +64,6 @@ All datasets in our lab follow a structured hierarchy to ensure logical arrangem
 
 The LEGO Data Model includes five domains, accessible via : 
 
-* **FASSE** `/n/dominici_nsaph_l3/Lab/lego` 
 * **CANNON** `/n/dominici_lab/lab/lego` (excluding health)
 * **ReD** `lab_share/data/lego` (`lab_share` refers to the lab share directory, which remains confidential for security reasons)
 

--- a/handbook/mcbs.md
+++ b/handbook/mcbs.md
@@ -35,13 +35,16 @@ In 2015, Hispanic beneficiaries living outside of Puerto Rico were intentionally
 
 
 ### Data Location and Contents
-The survey files contain information regarding various aspects of the beneficiaries' lives, including topics such as their housing, demographic information, income, and health status. Prior to 2015, these files were labeled "RIC-X" for the various topics, but now they are labeled with titles that reflect their contents, e.g. "Health Status and Functioning (HFQ)". The questions about nicotine and alcohol are included within the nicoalco.csv file under the Survey folder (`/n/dominici_nsaph_l3/data/mcbs/2015/survey_file/data/csv/nicoalco.csv` within FASSE). In order to match these patients with their demographic information, use the demo.csv file with variable BASEID.
+Data Location and Contents
+The survey files contain information regarding various aspects of the beneficiaries’ lives, including topics such as their housing, demographic information, income, and health status. Prior to 2015, these files were labeled “RIC-X” for the various topics, but now they are labeled with titles that reflect their contents, e.g. “Health Status and Functioning (HFQ)”. The questions about nicotine and alcohol are included within the nicoalco.csv file under the Survey folder in the MCBS directory (located in the ReD lab share under `lab_share/data/play-doh/`). In order to match these patients with their demographic information, use the demo.csv file with variable BASEID.
 
-In order to learn what each variable represents in these files, please reference the Codebooks folder. For example, to access the code book for the nicotine and alcohol survey, you can navigate to `/n/dominici_nsaph_l3/data/mcbs/2015/survey_file/codebooks/nicoalco_2015.txt` in FASSE to get the codebook. Some variables include the number of drinks per day, if the beneficiary currently smokes, if they ever smoked, etc. The demographic file codebook contains information such as DOB, sex, race, income, state, county, and zipcode. 
+In order to learn what each variable represents in these files, please reference the Codebooks folder. For example, to access the code book for the nicotine and alcohol survey, you can navigate to the corresponding codebooks directory within `lab_share/data/play-doh/` to get the codebook. Some variables include the number of drinks per day, if the beneficiary currently smokes, if they ever smoked, etc. The demographic file codebook contains information such as DOB, sex, race, income, state, county, and zipcode.
+
+
 
 #### Data Tree
 
-To access MCBS data, please open FASSE and navigate to `/n/dominici_nsaph_l3/data/mcbs/2015/`. Below, you can see a data tree reflecting the folder structure of the `2015` folder:
+To access MCBS data, navigate to the MCBS directory within the ReD lab share (under `lab_share/data/play-doh/`). Below, you can see a data tree reflecting the folder structure of the `2015` folder:
 
 ``` 
 |-- cost_supplement

--- a/handbook/project_setup.md
+++ b/handbook/project_setup.md
@@ -68,14 +68,14 @@ If you are not familiar with using `git`, check out this [git tutorial](https://
 Also, check out [our guidelines](https://nsaph.github.io/handbook/collaborative.html) for collaborative work on GitHub.
 
 ````{note}
-If this is the first time you use github you might have to configure your account in FASSE by typing the commands below in FASSE's command line. 
+If this is the first time you use GitHub, you may need to configure your account by typing the commands below in your terminal. 
 
 ```
 git config --global user.name "Mona Lisa"
 git config --global user.email "email@example.com"
 ```
 
-By doing this, all code contributions (commits) from FASSE will be linked to your GitHub account.
+By doing this, all code contributions (commits) will be linked to your GitHub account.
 ````
 
 ### ReD: 
@@ -151,8 +151,8 @@ A scratch space provides a dedicated area for temporary storage and facilitates 
 **When to use a scratch space?** Whenever you need a temporary storage for intermediate data during processing or computations, use it to store data that is being actively manipulated or processed but is not needed for long-term storage.
 
 **Example scratch space usages**
-1. When creating a large dataset compiled from several analytic datasets. Merged data is large but takes time to compile so you want to save it to use for analyses but not take up valuable space on FASSE. Instead store the compiled dataset in scratch and access each time you need to run your analysis. if the merged dataset goes unmodified for 90 days it may be deleted, in which case you will need to rerun your script to merge the data.
-2. For bootstrap analyses it is often quicker to create a set of bootstrap datasets. these datasets individually are large and collectively would overrun the usable space on FASSE. instead, store the temporary datasets in scratch and then have your bootstrap analyses load each individually. delete after use!
+1. When creating a large dataset compiled from several analytic datasets. Merged data is large but takes time to compile so you want to save it to use for analyses but not take up valuable space on CANNON. Instead store the compiled dataset in scratch and access each time you need to run your analysis. if the merged dataset goes unmodified for 90 days it may be deleted, in which case you will need to rerun your script to merge the data.
+2. For bootstrap analyses it is often quicker to create a set of bootstrap datasets. these datasets individually are large and collectively would overrun the usable space on CANNON. instead, store the temporary datasets in scratch and then have your bootstrap analyses load each individually. delete after use!
 
 
 #### The lab has scratch spaces only available within CANNON: 
@@ -162,7 +162,7 @@ CANNON path:
 /n/netscratch/dominici_lab/Lab/<your-project-subdirectory>
 ```
 
-**How to use the scratch folder?** Create your own directory in this scratch space using your project name. For example, if your FASSE project name is `heat-stress-project`, then create a folder within the FASSE scratch folder: 
+**How to use the scratch folder?** Create your own directory in this scratch space using your project name. For example, if your CANNON project name is `heat-stress-project`, then create a folder within the CANNON scratch folder: 
 
 `mkdir /n/netscratch/dominici_lab/Lab/heat-stress-project`
 


### PR DESCRIPTION
This PR removes outdated references to FASSE across the handbook and updates language to align with current environments. Changes were made in the following sections:

Policies & Trainings → Data Usage Policies
Data Management → LEGO Data Model
Data Management → MCBS
Computing Infrastructure → Setting up your Work Space on an HPC
Reproducibility → Introduction to NSAPH GitHub

FASSE-specific paths and instructions were replaced with ReD lab share placeholders or generalized wording, and HPC-related content now reflects Cannon where appropriate. Existing workflows were preserved.

Closes #102 